### PR TITLE
Angular templated settings via OpenShift env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # eagle-helper-pods
+
 High level functional tests and deployment scripts for EAO EPIC (revision 2019) helper pods
 
 ## Related projects

--- a/openshift/setup-teardown/params/CUSTOM_SETTINGS/CAP/admin/dev/admin-4-angular-on-nginx-dc.params
+++ b/openshift/setup-teardown/params/CUSTOM_SETTINGS/CAP/admin/dev/admin-4-angular-on-nginx-dc.params
@@ -3,4 +3,5 @@ GROUP_NAME=cap-eagle-epic
 IMAGE_NAMESPACE=oabrei-dev
 APPLICATION_DOMAIN=cap-eagle-dev.pathfinder.gov.bc.ca
 TAG_NAME=dev
-REMOTE_API_PATH=cap-eagle-dev.pathfinder.gov.bc.ca/api
+REMOTE_API_PATH=https://cap-eagle-dev.pathfinder.gov.bc.ca/api
+REMOTE_PUBLIC_PATH=https://cap-eagle-dev.pathfinder.gov.bc.ca

--- a/openshift/setup-teardown/params/CUSTOM_SETTINGS/CAP/admin/prod/admin-4-angular-on-nginx-dc.params
+++ b/openshift/setup-teardown/params/CUSTOM_SETTINGS/CAP/admin/prod/admin-4-angular-on-nginx-dc.params
@@ -3,4 +3,5 @@ GROUP_NAME=cap-eagle-epic
 IMAGE_NAMESPACE=oabrei-prod
 APPLICATION_DOMAIN=cap-eagle-prod.pathfinder.gov.bc.ca
 TAG_NAME=prod
-REMOTE_API_PATH=cap-eagle-prod.pathfinder.gov.bc.ca/api
+REMOTE_API_PATH=https://cap-eagle-prod.pathfinder.gov.bc.ca/api
+REMOTE_PUBLIC_PATH=https://cap-eagle-prod.pathfinder.gov.bc.ca

--- a/openshift/setup-teardown/params/CUSTOM_SETTINGS/CAP/admin/test/admin-4-angular-on-nginx-dc.params
+++ b/openshift/setup-teardown/params/CUSTOM_SETTINGS/CAP/admin/test/admin-4-angular-on-nginx-dc.params
@@ -3,4 +3,5 @@ GROUP_NAME=cap-eagle-epic
 IMAGE_NAMESPACE=oabrei-test
 APPLICATION_DOMAIN=cap-eagle-test.pathfinder.gov.bc.ca
 TAG_NAME=test
-REMOTE_API_PATH=cap-eagle-test.pathfinder.gov.bc.ca/api
+REMOTE_API_PATH=https://cap-eagle-test.pathfinder.gov.bc.ca/api
+REMOTE_PUBLIC_PATH=https://cap-eagle-test.pathfinder.gov.bc.ca

--- a/openshift/setup-teardown/params/CUSTOM_SETTINGS/CAP/environment.md
+++ b/openshift/setup-teardown/params/CUSTOM_SETTINGS/CAP/environment.md
@@ -1,0 +1,3 @@
+# Deployment Package Description
+
+Settings and params for the Cloud Adoption Patterns team work, provided as an example of how to deploy eagle with different names and repos.

--- a/openshift/setup-teardown/params/CUSTOM_SETTINGS/CAP/public/dev/public-4-angular-on-nginx-dc.params
+++ b/openshift/setup-teardown/params/CUSTOM_SETTINGS/CAP/public/dev/public-4-angular-on-nginx-dc.params
@@ -3,5 +3,5 @@ GROUP_NAME=cap-eagle-epic
 IMAGE_NAMESPACE=oabrei-dev
 APPLICATION_DOMAIN=cap-eagle-dev.pathfinder.gov.bc.ca
 TAG_NAME=dev
-REMOTE_API_PATH=cap-eagle-dev.pathfinder.gov.bc.ca/api/public
-REMOTE_ADMIN_PATH=cap-eagle-dev.pathfinder.gov.bc.ca/admin/
+REMOTE_API_PATH=https://cap-eagle-dev.pathfinder.gov.bc.ca/api/public
+REMOTE_ADMIN_PATH=https://cap-eagle-dev.pathfinder.gov.bc.ca/admin/

--- a/openshift/setup-teardown/params/CUSTOM_SETTINGS/CAP/public/prod/public-4-angular-on-nginx-dc.params
+++ b/openshift/setup-teardown/params/CUSTOM_SETTINGS/CAP/public/prod/public-4-angular-on-nginx-dc.params
@@ -3,5 +3,5 @@ GROUP_NAME=cap-eagle-epic
 IMAGE_NAMESPACE=oabrei-prod
 APPLICATION_DOMAIN=cap-eagle-prod.pathfinder.gov.bc.ca
 TAG_NAME=prod
-REMOTE_API_PATH=cap-eagle-prod.pathfinder.gov.bc.ca/api/public
-REMOTE_ADMIN_PATH=cap-eagle-prod.pathfinder.gov.bc.ca/admin/
+REMOTE_API_PATH=https://cap-eagle-prod.pathfinder.gov.bc.ca/api/public
+REMOTE_ADMIN_PATH=https://cap-eagle-prod.pathfinder.gov.bc.ca/admin/

--- a/openshift/setup-teardown/params/CUSTOM_SETTINGS/CAP/public/test/public-4-angular-on-nginx-dc.params
+++ b/openshift/setup-teardown/params/CUSTOM_SETTINGS/CAP/public/test/public-4-angular-on-nginx-dc.params
@@ -3,5 +3,5 @@ GROUP_NAME=cap-eagle-epic
 IMAGE_NAMESPACE=oabrei-test
 APPLICATION_DOMAIN=cap-eagle-test.pathfinder.gov.bc.ca
 TAG_NAME=test
-REMOTE_API_PATH=cap-eagle-test.pathfinder.gov.bc.ca/api/public
-REMOTE_ADMIN_PATH=cap-eagle-test.pathfinder.gov.bc.ca/admin/
+REMOTE_API_PATH=https://cap-eagle-test.pathfinder.gov.bc.ca/api/public
+REMOTE_ADMIN_PATH=https://cap-eagle-test.pathfinder.gov.bc.ca/admin/

--- a/openshift/setup-teardown/params/CUSTOM_SETTINGS/EAGLE/admin/dev/admin-4-angular-on-nginx-dc.params
+++ b/openshift/setup-teardown/params/CUSTOM_SETTINGS/EAGLE/admin/dev/admin-4-angular-on-nginx-dc.params
@@ -3,4 +3,5 @@ GROUP_NAME=eagle-epic
 IMAGE_NAMESPACE=noexist-tools
 APPLICATION_DOMAIN=eagle-noexist-dev.pathfinder.gov.bc.ca
 TAG_NAME=dev
-REMOTE_API_PATH=eagle-noexist-dev.pathfinder.gov.bc.ca/api
+REMOTE_API_PATH=https://eagle-noexist-dev.pathfinder.gov.bc.ca/api
+REMOTE_PUBLIC_PATH=https://eagle-noexist-dev.pathfinder.gov.bc.ca

--- a/openshift/setup-teardown/params/CUSTOM_SETTINGS/EAGLE/admin/prod/admin-4-angular-on-nginx-dc.params
+++ b/openshift/setup-teardown/params/CUSTOM_SETTINGS/EAGLE/admin/prod/admin-4-angular-on-nginx-dc.params
@@ -3,4 +3,5 @@ GROUP_NAME=eagle-epic
 IMAGE_NAMESPACE=noexist-tools
 APPLICATION_DOMAIN=eagle-noexist-prod.pathfinder.gov.bc.ca
 TAG_NAME=prod
-REMOTE_API_PATH=eagle-noexist-prod.pathfinder.gov.bc.ca/api
+REMOTE_API_PATH=https://eagle-noexist-prod.pathfinder.gov.bc.ca/api
+REMOTE_PUBLIC_PATH=https://eagle-noexist-prod.pathfinder.gov.bc.ca

--- a/openshift/setup-teardown/params/CUSTOM_SETTINGS/EAGLE/admin/test/admin-4-angular-on-nginx-dc.params
+++ b/openshift/setup-teardown/params/CUSTOM_SETTINGS/EAGLE/admin/test/admin-4-angular-on-nginx-dc.params
@@ -3,4 +3,5 @@ GROUP_NAME=eagle-epic
 IMAGE_NAMESPACE=noexist-tools
 APPLICATION_DOMAIN=eagle-noexist-test.pathfinder.gov.bc.ca
 TAG_NAME=test
-REMOTE_API_PATH=eagle-noexist-test.pathfinder.gov.bc.ca/api
+REMOTE_API_PATH=https://eagle-noexist-test.pathfinder.gov.bc.ca/api
+REMOTE_PUBLIC_PATH=https://eagle-noexist-test.pathfinder.gov.bc.ca

--- a/openshift/setup-teardown/params/CUSTOM_SETTINGS/EAGLE/environment.md
+++ b/openshift/setup-teardown/params/CUSTOM_SETTINGS/EAGLE/environment.md
@@ -1,0 +1,3 @@
+# Deployment Package Description
+
+Settings and params for the main EPIC EAGLE environments.  This is a live production site, so some settings have had the text "noexist" inserted in lieu of the real OpenShift environment name as a safety measure to prevent accidental teardowns.

--- a/openshift/setup-teardown/params/CUSTOM_SETTINGS/EAGLE/public/dev/public-4-angular-on-nginx-dc.params
+++ b/openshift/setup-teardown/params/CUSTOM_SETTINGS/EAGLE/public/dev/public-4-angular-on-nginx-dc.params
@@ -3,5 +3,5 @@ GROUP_NAME=eagle-epic
 IMAGE_NAMESPACE=noexist-tools
 APPLICATION_DOMAIN=eagle-noexist-dev.pathfinder.gov.bc.ca
 TAG_NAME=dev
-REMOTE_API_PATH=eagle-noexist-dev.pathfinder.gov.bc.ca/api/public
-REMOTE_ADMIN_PATH=eagle-noexist-dev.pathfinder.gov.bc.ca/admin/
+REMOTE_API_PATH=https://eagle-noexist-dev.pathfinder.gov.bc.ca/api/public
+REMOTE_ADMIN_PATH=https://eagle-noexist-dev.pathfinder.gov.bc.ca/admin/

--- a/openshift/setup-teardown/params/CUSTOM_SETTINGS/EAGLE/public/prod/public-4-angular-on-nginx-dc.params
+++ b/openshift/setup-teardown/params/CUSTOM_SETTINGS/EAGLE/public/prod/public-4-angular-on-nginx-dc.params
@@ -3,5 +3,5 @@ GROUP_NAME=eagle-epic
 IMAGE_NAMESPACE=noexist-tools
 APPLICATION_DOMAIN=eagle-noexist-prod.pathfinder.gov.bc.ca
 TAG_NAME=prod
-REMOTE_API_PATH=eagle-noexist-prod.pathfinder.gov.bc.ca/api/public
-REMOTE_ADMIN_PATH=eagle-noexist-prod.pathfinder.gov.bc.ca/admin/
+REMOTE_API_PATH=https://eagle-noexist-prod.pathfinder.gov.bc.ca/api/public
+REMOTE_ADMIN_PATH=https://eagle-noexist-prod.pathfinder.gov.bc.ca/admin/

--- a/openshift/setup-teardown/params/CUSTOM_SETTINGS/EAGLE/public/test/public-4-angular-on-nginx-dc.params
+++ b/openshift/setup-teardown/params/CUSTOM_SETTINGS/EAGLE/public/test/public-4-angular-on-nginx-dc.params
@@ -3,5 +3,5 @@ GROUP_NAME=eagle-epic
 IMAGE_NAMESPACE=noexist-tools
 APPLICATION_DOMAIN=eagle-noexist-test.pathfinder.gov.bc.ca
 TAG_NAME=test
-REMOTE_API_PATH=eagle-noexist-test.pathfinder.gov.bc.ca/api/public
-REMOTE_ADMIN_PATH=eagle-noexist-test.pathfinder.gov.bc.ca/admin/
+REMOTE_API_PATH=https://eagle-noexist-test.pathfinder.gov.bc.ca/api/public
+REMOTE_ADMIN_PATH=https://eagle-noexist-test.pathfinder.gov.bc.ca/admin/

--- a/openshift/setup-teardown/params/CUSTOM_SETTINGS/EAGLE_DEMO/admin/dev/admin-4-angular-on-nginx-dc.params
+++ b/openshift/setup-teardown/params/CUSTOM_SETTINGS/EAGLE_DEMO/admin/dev/admin-4-angular-on-nginx-dc.params
@@ -3,4 +3,5 @@ GROUP_NAME=demo-eagle-epic
 IMAGE_NAMESPACE=noexist-tools
 APPLICATION_DOMAIN=demo-eagle-noexist-dev.pathfinder.gov.bc.ca
 TAG_NAME=dev
-REMOTE_API_PATH=demo-eagle-noexist-dev.pathfinder.gov.bc.ca/api
+REMOTE_API_PATH=https://demo-eagle-noexist-dev.pathfinder.gov.bc.ca/api
+REMOTE_PUBLIC_PATH=https://demo-eagle-noexist-dev.pathfinder.gov.bc.ca

--- a/openshift/setup-teardown/params/CUSTOM_SETTINGS/EAGLE_DEMO/admin/prod/admin-4-angular-on-nginx-dc.params
+++ b/openshift/setup-teardown/params/CUSTOM_SETTINGS/EAGLE_DEMO/admin/prod/admin-4-angular-on-nginx-dc.params
@@ -3,4 +3,5 @@ GROUP_NAME=demo-eagle-epic
 IMAGE_NAMESPACE=noexist-tools
 APPLICATION_DOMAIN=demo-eagle-noexist-prod.pathfinder.gov.bc.ca
 TAG_NAME=prod
-REMOTE_API_PATH=demo-eagle-noexist-prod.pathfinder.gov.bc.ca/api
+REMOTE_API_PATH=https://demo-eagle-noexist-prod.pathfinder.gov.bc.ca/api
+REMOTE_PUBLIC_PATH=https://demo-eagle-noexist-prod.pathfinder.gov.bc.ca

--- a/openshift/setup-teardown/params/CUSTOM_SETTINGS/EAGLE_DEMO/admin/test/admin-4-angular-on-nginx-dc.params
+++ b/openshift/setup-teardown/params/CUSTOM_SETTINGS/EAGLE_DEMO/admin/test/admin-4-angular-on-nginx-dc.params
@@ -3,4 +3,5 @@ GROUP_NAME=demo-eagle-epic
 IMAGE_NAMESPACE=noexist-tools
 APPLICATION_DOMAIN=demo-eagle-noexist-test.pathfinder.gov.bc.ca
 TAG_NAME=test
-REMOTE_API_PATH=demo-eagle-noexist-test.pathfinder.gov.bc.ca/api
+REMOTE_API_PATH=https://demo-eagle-noexist-test.pathfinder.gov.bc.ca/api
+REMOTE_PUBLIC_PATH=https://demo-eagle-noexist-test.pathfinder.gov.bc.ca

--- a/openshift/setup-teardown/params/CUSTOM_SETTINGS/EAGLE_DEMO/environment.md
+++ b/openshift/setup-teardown/params/CUSTOM_SETTINGS/EAGLE_DEMO/environment.md
@@ -1,0 +1,5 @@
+# Deployment Package Description
+
+Settings and params for a temporary EPIC Eagle demo deployment, provided as an example of how to deploy eagle alongside other existing eagle components in the same OpenShift namespace but with different names, same repos, different branches.  
+
+For safety as EAO staff are expecting this deployment to be available for a limited time, the text "no-exist" has been used throughout in lieu of the actual namespace license plate text.  Pull this down locally replace the text.  Take care to only replace it in EAGLE_DEMO and not EAGLE so you never accidentally wipe production eagle.

--- a/openshift/setup-teardown/params/CUSTOM_SETTINGS/EAGLE_DEMO/public/dev/public-4-angular-on-nginx-dc.params
+++ b/openshift/setup-teardown/params/CUSTOM_SETTINGS/EAGLE_DEMO/public/dev/public-4-angular-on-nginx-dc.params
@@ -3,5 +3,5 @@ GROUP_NAME=demo-eagle-epic
 IMAGE_NAMESPACE=noexist-tools
 APPLICATION_DOMAIN=demo-eagle-noexist-dev.pathfinder.gov.bc.ca
 TAG_NAME=dev
-REMOTE_API_PATH=demo-eagle-noexist-dev.pathfinder.gov.bc.ca/api/public
-REMOTE_ADMIN_PATH=demo-eagle-noexist-dev.pathfinder.gov.bc.ca/admin/
+REMOTE_API_PATH=https://demo-eagle-noexist-dev.pathfinder.gov.bc.ca/api/public
+REMOTE_ADMIN_PATH=https://demo-eagle-noexist-dev.pathfinder.gov.bc.ca/admin/

--- a/openshift/setup-teardown/params/CUSTOM_SETTINGS/EAGLE_DEMO/public/prod/public-4-angular-on-nginx-dc.params
+++ b/openshift/setup-teardown/params/CUSTOM_SETTINGS/EAGLE_DEMO/public/prod/public-4-angular-on-nginx-dc.params
@@ -3,5 +3,5 @@ GROUP_NAME=demo-eagle-epic
 IMAGE_NAMESPACE=noexist-prod
 APPLICATION_DOMAIN=demo-eagle-noexist-prod.pathfinder.gov.bc.ca
 TAG_NAME=prod
-REMOTE_API_PATH=demo-eagle-noexist-prod.pathfinder.gov.bc.ca/api/public
-REMOTE_ADMIN_PATH=demo-eagle-noexist-prod.pathfinder.gov.bc.ca/admin/
+REMOTE_API_PATH=https://demo-eagle-noexist-prod.pathfinder.gov.bc.ca/api/public
+REMOTE_ADMIN_PATH=https://demo-eagle-noexist-prod.pathfinder.gov.bc.ca/admin/

--- a/openshift/setup-teardown/params/CUSTOM_SETTINGS/EAGLE_DEMO/public/test/public-4-angular-on-nginx-dc.params
+++ b/openshift/setup-teardown/params/CUSTOM_SETTINGS/EAGLE_DEMO/public/test/public-4-angular-on-nginx-dc.params
@@ -3,5 +3,5 @@ GROUP_NAME=demo-eagle-epic
 IMAGE_NAMESPACE=noexist-tools
 APPLICATION_DOMAIN=demo-eagle-noexist-test.pathfinder.gov.bc.ca
 TAG_NAME=test
-REMOTE_API_PATH=demo-eagle-noexist-test.pathfinder.gov.bc.ca/api/public
-REMOTE_ADMIN_PATH=demo-eagle-noexist-test.pathfinder.gov.bc.ca/admin/
+REMOTE_API_PATH=https://demo-eagle-noexist-test.pathfinder.gov.bc.ca/api/public
+REMOTE_ADMIN_PATH=https://demo-eagle-noexist-test.pathfinder.gov.bc.ca/admin/

--- a/openshift/setup-teardown/params/CUSTOM_SETTINGS/ROUTES_AS_SETTINGS/admin/admin.config
+++ b/openshift/setup-teardown/params/CUSTOM_SETTINGS/ROUTES_AS_SETTINGS/admin/admin.config
@@ -1,0 +1,8 @@
+ADMIN_ANGULAR_BUILDER_BUILD_NAME=routes-as-settings-admin-angular-builder
+ADMIN_NGINX_RUNTIME_BUILD_NAME=routes-as-settings-admin-nginx-runtime
+ADMIN_ANGULAR_ON_NGINX_BUILD_NAME=routes-as-settings-admin
+ADMIN_ANGULAR_ON_NGINX_DEPLOYMENT_NAME=routes-as-settings-admin
+ADMIN_BC_ANGULAR_BUILDER_TEMPLATE_FOLDER_URL=https://raw.githubusercontent.com/ActionAnalytics/eagle-admin/routes-as-settings2/openshift/templates/angular-builder/
+ADMIN_BC_NGINX_RUNTIME_TEMPLATE_FOLDER_URL=https://raw.githubusercontent.com/ActionAnalytics/eagle-admin/routes-as-settings2/openshift/templates/nginx-runtime/
+ADMIN_BC_ANGULAR_ON_NGINX_TEMPLATE_FOLDER_URL=https://raw.githubusercontent.com/ActionAnalytics/eagle-admin/routes-as-settings2/openshift/templates/angular-on-nginx/
+ADMIN_DC_ANGULAR_ON_NGINX_TEMPLATE_FOLDER_URL=https://raw.githubusercontent.com/ActionAnalytics/eagle-admin/routes-as-settings2/openshift/templates/angular-on-nginx/

--- a/openshift/setup-teardown/params/CUSTOM_SETTINGS/ROUTES_AS_SETTINGS/admin/dev/admin-4-angular-on-nginx-dc.params
+++ b/openshift/setup-teardown/params/CUSTOM_SETTINGS/ROUTES_AS_SETTINGS/admin/dev/admin-4-angular-on-nginx-dc.params
@@ -1,0 +1,7 @@
+NAME=routes-as-settings-admin
+GROUP_NAME=routes-as-settings
+IMAGE_NAMESPACE=oabrei-dev
+APPLICATION_DOMAIN=routes-as-settings-dev.pathfinder.gov.bc.ca
+TAG_NAME=dev
+REMOTE_API_PATH=https://routes-as-settings-dev.pathfinder.gov.bc.ca/api
+REMOTE_PUBLIC_PATH=https://routes-as-settings-dev.pathfinder.gov.bc.ca

--- a/openshift/setup-teardown/params/CUSTOM_SETTINGS/ROUTES_AS_SETTINGS/admin/prod/admin-4-angular-on-nginx-dc.params
+++ b/openshift/setup-teardown/params/CUSTOM_SETTINGS/ROUTES_AS_SETTINGS/admin/prod/admin-4-angular-on-nginx-dc.params
@@ -1,0 +1,7 @@
+NAME=routes-as-settings-admin
+GROUP_NAME=routes-as-settings
+IMAGE_NAMESPACE=oabrei-prod
+APPLICATION_DOMAIN=routes-as-settings-prod.pathfinder.gov.bc.ca
+TAG_NAME=prod
+REMOTE_API_PATH=https://routes-as-settings-prod.pathfinder.gov.bc.ca/api
+REMOTE_PUBLIC_PATH=https://routes-as-settings-prod.pathfinder.gov.bc.ca

--- a/openshift/setup-teardown/params/CUSTOM_SETTINGS/ROUTES_AS_SETTINGS/admin/test/admin-4-angular-on-nginx-dc.params
+++ b/openshift/setup-teardown/params/CUSTOM_SETTINGS/ROUTES_AS_SETTINGS/admin/test/admin-4-angular-on-nginx-dc.params
@@ -1,0 +1,7 @@
+NAME=routes-as-settings-admin
+GROUP_NAME=routes-as-settings
+IMAGE_NAMESPACE=oabrei-test
+APPLICATION_DOMAIN=routes-as-settings-test.pathfinder.gov.bc.ca
+TAG_NAME=test
+REMOTE_API_PATH=https://routes-as-settings-test.pathfinder.gov.bc.ca/api
+REMOTE_PUBLIC_PATH=https://routes-as-settings-test.pathfinder.gov.bc.ca

--- a/openshift/setup-teardown/params/CUSTOM_SETTINGS/ROUTES_AS_SETTINGS/admin/tools/admin-1-angular-builder-bc.params
+++ b/openshift/setup-teardown/params/CUSTOM_SETTINGS/ROUTES_AS_SETTINGS/admin/tools/admin-1-angular-builder-bc.params
@@ -1,0 +1,3 @@
+NAME=routes-as-settings-admin-angular-builder
+GIT_REPO_URL=https://github.com/ActionAnalytics/eagle-admin
+GIT_REPO_BRANCH=routes-as-settings2

--- a/openshift/setup-teardown/params/CUSTOM_SETTINGS/ROUTES_AS_SETTINGS/admin/tools/admin-2-nginx-runtime-bc.params
+++ b/openshift/setup-teardown/params/CUSTOM_SETTINGS/ROUTES_AS_SETTINGS/admin/tools/admin-2-nginx-runtime-bc.params
@@ -1,0 +1,3 @@
+NAME=routes-as-settings-admin-nginx-runtime
+GIT_REPO_URL=https://github.com/ActionAnalytics/eagle-admin
+GIT_REPO_BRANCH=routes-as-settings2

--- a/openshift/setup-teardown/params/CUSTOM_SETTINGS/ROUTES_AS_SETTINGS/admin/tools/admin-3-angular-on-nginx-bc.params
+++ b/openshift/setup-teardown/params/CUSTOM_SETTINGS/ROUTES_AS_SETTINGS/admin/tools/admin-3-angular-on-nginx-bc.params
@@ -1,0 +1,3 @@
+NAME=routes-as-settings-admin
+ANGULAR_BUILDER_IMAGE=routes-as-settings-admin-angular-builder
+NGINX_RUNTIME_IMAGE=routes-as-settings-admin-nginx-runtime

--- a/openshift/setup-teardown/params/CUSTOM_SETTINGS/ROUTES_AS_SETTINGS/api/api.config
+++ b/openshift/setup-teardown/params/CUSTOM_SETTINGS/ROUTES_AS_SETTINGS/api/api.config
@@ -1,0 +1,7 @@
+API_NODEJS_BUILD_NAME=routes-as-settings-api
+API_NODEJS_DEPLOYMENT_NAME=routes-as-settings-api
+API_MONGODB_DEPLOYMENT_NAME=routes-as-settings-api-mongodb
+API_MINIO_DEPLOYMENT_NAME=routes-as-settings-api-minio
+API_BC_NODEJS_TEMPLATE_FOLDER_URL=https://raw.githubusercontent.com/ActionAnalytics/eagle-api/routes-as-settings2/openshift/templates/
+API_DC_MINIO_TEMPLATE_FOLDER_URL=https://raw.githubusercontent.com/ActionAnalytics/eagle-api/routes-as-settings2/openshift/templates/
+API_DC_NODEJS_AND_MONGO_TEMPLATE_FOLDER_URL=https://raw.githubusercontent.com/ActionAnalytics/eagle-api/routes-as-settings2/openshift/templates/

--- a/openshift/setup-teardown/params/CUSTOM_SETTINGS/ROUTES_AS_SETTINGS/api/dev/api-2-minio-dc.params
+++ b/openshift/setup-teardown/params/CUSTOM_SETTINGS/ROUTES_AS_SETTINGS/api/dev/api-2-minio-dc.params
@@ -1,0 +1,2 @@
+NAME=cap-eagle-api-minio
+GROUP_NAME=cap-eagle-epic

--- a/openshift/setup-teardown/params/CUSTOM_SETTINGS/ROUTES_AS_SETTINGS/api/dev/api-3-nodejs-dc.params
+++ b/openshift/setup-teardown/params/CUSTOM_SETTINGS/ROUTES_AS_SETTINGS/api/dev/api-3-nodejs-dc.params
@@ -1,0 +1,9 @@
+NAME=cap-eagle-api
+GROUP_NAME=cap-eagle-epic
+APPLICATION_DOMAIN=cap-eagle-dev.pathfinder.gov.bc.ca
+MINIO_HOST=cap-eagle-api-minio-oabrei-dev.pathfinder.gov.bc.ca
+MINIO_SECRET_NAME=cap-eagle-api-minio-keys
+DATABASE_SERVICE_NAME=cap-eagle-api-mongodb
+APP_IMAGE_NAME=cap-eagle-api
+APP_IMAGE_NAMESPACE=oabrei-dev
+APP_DEPLOYMENT_TAG=dev

--- a/openshift/setup-teardown/params/CUSTOM_SETTINGS/ROUTES_AS_SETTINGS/api/prod/api-2-minio-dc.params
+++ b/openshift/setup-teardown/params/CUSTOM_SETTINGS/ROUTES_AS_SETTINGS/api/prod/api-2-minio-dc.params
@@ -1,0 +1,2 @@
+NAME=cap-eagle-api-minio
+GROUP_NAME=cap-eagle-epic

--- a/openshift/setup-teardown/params/CUSTOM_SETTINGS/ROUTES_AS_SETTINGS/api/prod/api-3-nodejs-dc.params
+++ b/openshift/setup-teardown/params/CUSTOM_SETTINGS/ROUTES_AS_SETTINGS/api/prod/api-3-nodejs-dc.params
@@ -1,0 +1,9 @@
+NAME=cap-eagle-api
+GROUP_NAME=cap-eagle-epic
+APPLICATION_DOMAIN=cap-eagle-prod.pathfinder.gov.bc.ca
+MINIO_HOST=cap-eagle-api-minio-oabrei-prod.pathfinder.gov.bc.ca
+MINIO_SECRET_NAME=cap-eagle-api-minio-keys
+DATABASE_SERVICE_NAME=cap-eagle-api-mongodb
+APP_IMAGE_NAME=cap-eagle-api
+APP_IMAGE_NAMESPACE=oabrei-prod
+APP_DEPLOYMENT_TAG=prod

--- a/openshift/setup-teardown/params/CUSTOM_SETTINGS/ROUTES_AS_SETTINGS/api/test/api-2-minio-dc.params
+++ b/openshift/setup-teardown/params/CUSTOM_SETTINGS/ROUTES_AS_SETTINGS/api/test/api-2-minio-dc.params
@@ -1,0 +1,2 @@
+NAME=routes-as-settings-api-minio
+GROUP_NAME=routes-as-settings

--- a/openshift/setup-teardown/params/CUSTOM_SETTINGS/ROUTES_AS_SETTINGS/api/test/api-3-nodejs-dc.params
+++ b/openshift/setup-teardown/params/CUSTOM_SETTINGS/ROUTES_AS_SETTINGS/api/test/api-3-nodejs-dc.params
@@ -1,0 +1,9 @@
+NAME=routes-as-settings-api
+GROUP_NAME=routes-as-settings
+APPLICATION_DOMAIN=routes-as-settings-test.pathfinder.gov.bc.ca
+MINIO_HOST=routes-as-settings-api-minio-oabrei-test.pathfinder.gov.bc.ca
+MINIO_SECRET_NAME=routes-as-settings-api-minio-keys
+DATABASE_SERVICE_NAME=routes-as-settings-api-mongodb
+APP_IMAGE_NAME=routes-as-settings-api
+APP_IMAGE_NAMESPACE=oabrei-test
+APP_DEPLOYMENT_TAG=test

--- a/openshift/setup-teardown/params/CUSTOM_SETTINGS/ROUTES_AS_SETTINGS/api/tools/api-1-nodejs-bc.params
+++ b/openshift/setup-teardown/params/CUSTOM_SETTINGS/ROUTES_AS_SETTINGS/api/tools/api-1-nodejs-bc.params
@@ -1,0 +1,3 @@
+NAME=routes-as-settings-api
+SOURCE_REPOSITORY_URL=https://github.com/ActionAnalytics/eagle-api
+SOURCE_REPOSITORY_REF=routes-as-settings2

--- a/openshift/setup-teardown/params/CUSTOM_SETTINGS/ROUTES_AS_SETTINGS/environment.config
+++ b/openshift/setup-teardown/params/CUSTOM_SETTINGS/ROUTES_AS_SETTINGS/environment.config
@@ -1,0 +1,4 @@
+TOOLS_PROJECT=oabrei-test
+TARGET_PROJECT=oabrei-test
+TAG=test
+GROUP_NAME=routes-as-settings

--- a/openshift/setup-teardown/params/CUSTOM_SETTINGS/ROUTES_AS_SETTINGS/environment.md
+++ b/openshift/setup-teardown/params/CUSTOM_SETTINGS/ROUTES_AS_SETTINGS/environment.md
@@ -1,0 +1,3 @@
+# Deployment Package Description
+
+Settings and params for the initial testing of this setup and teardown utility and the templetization of previously hard-coded routing settings in the Angular front-ends (now exposed as OpenShift environment variables).  This is provided as an example of how to deploy eagle from a forked version of the eagle repos, working on temporary branches with different names from the stock eagle deployments, alowing for side-by-side deployments in the same namespace.  Do make sure your names are unique in the param files before you follow this pattern.

--- a/openshift/setup-teardown/params/CUSTOM_SETTINGS/ROUTES_AS_SETTINGS/public/dev/public-4-angular-on-nginx-dc.params
+++ b/openshift/setup-teardown/params/CUSTOM_SETTINGS/ROUTES_AS_SETTINGS/public/dev/public-4-angular-on-nginx-dc.params
@@ -1,0 +1,7 @@
+NAME=routes-as-settings-public
+GROUP_NAME=routes-as-settings
+IMAGE_NAMESPACE=oabrei-dev
+APPLICATION_DOMAIN=cap-eagle-dev.pathfinder.gov.bc.ca
+TAG_NAME=dev
+REMOTE_API_PATH=https://routes-as-settings-dev.pathfinder.gov.bc.ca/api/public
+REMOTE_ADMIN_PATH=https://routes-as-settings-dev.pathfinder.gov.bc.ca/admin/

--- a/openshift/setup-teardown/params/CUSTOM_SETTINGS/ROUTES_AS_SETTINGS/public/prod/public-4-angular-on-nginx-dc.params
+++ b/openshift/setup-teardown/params/CUSTOM_SETTINGS/ROUTES_AS_SETTINGS/public/prod/public-4-angular-on-nginx-dc.params
@@ -1,0 +1,7 @@
+NAME=routes-as-settings-public
+GROUP_NAME=routes-as-settings
+IMAGE_NAMESPACE=oabrei-prod
+APPLICATION_DOMAIN=routes-as-settings-prod.pathfinder.gov.bc.ca
+TAG_NAME=prod
+REMOTE_API_PATH=https://routes-as-settings-prod.pathfinder.gov.bc.ca/api/public
+REMOTE_ADMIN_PATH=https://routes-as-settings-prod.pathfinder.gov.bc.ca/admin/

--- a/openshift/setup-teardown/params/CUSTOM_SETTINGS/ROUTES_AS_SETTINGS/public/public.config
+++ b/openshift/setup-teardown/params/CUSTOM_SETTINGS/ROUTES_AS_SETTINGS/public/public.config
@@ -1,0 +1,8 @@
+PUBLIC_ANGULAR_BUILDER_BUILD_NAME=routes-as-settings-public-angular-builder
+PUBLIC_NGINX_RUNTIME_BUILD_NAME=routes-as-settings-public-nginx-runtime
+PUBLIC_ANGULAR_ON_NGINX_BUILD_NAME=routes-as-settings-public
+PUBLIC_ANGULAR_ON_NGINX_DEPLOYMENT_NAME=routes-as-settings-public
+PUBLIC_BC_ANGULAR_BUILDER_TEMPLATE_FOLDER_URL=https://raw.githubusercontent.com/ActionAnalytics/eagle-public/routes-as-settings2/openshift/templates/angular-builder/
+PUBLIC_BC_NGINX_RUNTIME_TEMPLATE_FOLDER_URL=https://raw.githubusercontent.com/ActionAnalytics/eagle-public/routes-as-settings2/openshift/templates/nginx-runtime/
+PUBLIC_BC_ANGULAR_ON_NGINX_TEMPLATE_FOLDER_URL=https://raw.githubusercontent.com/ActionAnalytics/eagle-public/routes-as-settings2/openshift/templates/angular-on-nginx/
+PUBLIC_DC_ANGULAR_ON_NGINX_TEMPLATE_FOLDER_URL=https://raw.githubusercontent.com/ActionAnalytics/eagle-public/routes-as-settings2/openshift/templates/angular-on-nginx/

--- a/openshift/setup-teardown/params/CUSTOM_SETTINGS/ROUTES_AS_SETTINGS/public/test/public-4-angular-on-nginx-dc.params
+++ b/openshift/setup-teardown/params/CUSTOM_SETTINGS/ROUTES_AS_SETTINGS/public/test/public-4-angular-on-nginx-dc.params
@@ -1,0 +1,7 @@
+NAME=routes-as-settings-public
+GROUP_NAME=routes-as-settings
+IMAGE_NAMESPACE=oabrei-test
+APPLICATION_DOMAIN=routes-as-settings-test.pathfinder.gov.bc.ca
+TAG_NAME=test
+REMOTE_API_PATH=https://routes-as-settings-test.pathfinder.gov.bc.ca/api/public
+REMOTE_ADMIN_PATH=https://routes-as-settings-test.pathfinder.gov.bc.ca/admin/

--- a/openshift/setup-teardown/params/CUSTOM_SETTINGS/ROUTES_AS_SETTINGS/public/tools/public-1-angular-builder-bc.params
+++ b/openshift/setup-teardown/params/CUSTOM_SETTINGS/ROUTES_AS_SETTINGS/public/tools/public-1-angular-builder-bc.params
@@ -1,0 +1,3 @@
+NAME=routes-as-settings-public-angular-builder
+GIT_REPO_URL=https://github.com/ActionAnalytics/eagle-public
+GIT_REPO_BRANCH=routes-as-settings2

--- a/openshift/setup-teardown/params/CUSTOM_SETTINGS/ROUTES_AS_SETTINGS/public/tools/public-2-nginx-runtime-bc.params
+++ b/openshift/setup-teardown/params/CUSTOM_SETTINGS/ROUTES_AS_SETTINGS/public/tools/public-2-nginx-runtime-bc.params
@@ -1,0 +1,3 @@
+NAME=routes-as-settings-public-nginx-runtime
+GIT_REPO_URL=https://github.com/ActionAnalytics/eagle-public
+GIT_REPO_BRANCH=routes-as-settings2

--- a/openshift/setup-teardown/params/CUSTOM_SETTINGS/ROUTES_AS_SETTINGS/public/tools/public-3-angular-on-nginx-bc.params
+++ b/openshift/setup-teardown/params/CUSTOM_SETTINGS/ROUTES_AS_SETTINGS/public/tools/public-3-angular-on-nginx-bc.params
@@ -1,0 +1,3 @@
+NAME=routes-as-settings-public
+ANGULAR_BUILDER_IMAGE=routes-as-settings-public-angular-builder
+NGINX_RUNTIME_IMAGE=routes-as-settings-public-nginx-runtime

--- a/openshift/setup-teardown/setup-all.sh
+++ b/openshift/setup-teardown/setup-all.sh
@@ -155,3 +155,16 @@ loadEnvSettings $(<${ENV_ARGS_FILE});
 deployApi $(<${API_ARGS_FILE});
 deployAdmin $(<${ADMIN_ARGS_FILE});
 deployPublic $(<${PUBLIC_ARGS_FILE});
+
+
+# Go watch your builds.  In about 20 minutes they should complete.  
+# When they are done, run the following commands to trigger your deployments
+# Don't uncomment them here because they need to be run after the builds are done.  
+# Edit them to fit your settings and run them separately in a terminal.
+# Typically your-target-env is one of [dev, test, prod]
+
+###################################################### SNIP #######################################################
+#oc tag your-tools-namespace/your-app-name-api:latest your-tools-namespace/your-app-name-api:your-target-env
+#oc tag your-tools-namespace/your-app-name-public:latest your-tools-namespace/your-app-name-public:your-target-env
+#oc tag your-tools-namespace/your-app-name-admin:latest your-tools-namespace/your-app-name-admin:your-target-env
+#################################################### END SNIP #####################################################


### PR DESCRIPTION
This change is part of a 4 part changeset:

https://github.com/bcgov/eagle-helper-pods/pull/25
https://github.com/bcgov/eagle-admin/pull/330
https://github.com/bcgov/eagle-public/pull/179
https://github.com/bcgov/eagle-api/pull/284

Full working setup of EPIC using reliable and reproducible templated parameter files. 

Contains changes for the removal of hardcoded routes in Angular app and replacement with OpenShift environment variables.

Tested by doing clean deployment of API, Public and Admin.  A fresh prod db backup was edited using a local development instance of Admin to have a project name edited to have extra text "Resources As Settings" appended to its name in order to prove that we are looking at the correct database.

![Screen Shot 2019-11-20 at 12 41 01 AM](https://user-images.githubusercontent.com/37681273/69227419-9f7b0300-0b36-11ea-94e9-246cfd414ef9.png)

![Screen Shot 2019-11-20 at 12 42 05 AM](https://user-images.githubusercontent.com/37681273/69227451-aa359800-0b36-11ea-8870-457490fa92ff.png)

![Screen Shot 2019-11-20 at 12 50 59 AM](https://user-images.githubusercontent.com/37681273/69227479-b7eb1d80-0b36-11ea-90c4-7e374cf47db0.png)
