### PR TITLE
Update Dockerfile

### DIFF
--- a/docker-images/metabase/Dockerfile
+++ b/docker-images/metabase/Dockerfile
@@ -8,7 +8,7 @@ ENV LC_CTYPE en_US.UTF-8
 RUN apk add --update bash git wget make gettext ttf-dejavu fontconfig java-cacerts
 
 # add Metabase jar
-RUN wget -q http://downloads.metabase.com/v0.31.2/metabase.jar
+RUN wget -q http://downloads.metabase.com/v0.34.3/metabase.jar
 
 # create the plugins directory, with writable permissions
 RUN chmod -R 777 /app


### PR DESCRIPTION
Bump to latest version of metabase: https://github.com/metabase/metabase/releases/tag/v0.34.3

