### PR TITLE
add keycloack client id for PR deploys of eagle-admin

### DIFF
--- a/openshift/setup-teardown/params/CUSTOM_SETTINGS/PR/admin/dev/admin-4-angular-on-nginx-dc.params
+++ b/openshift/setup-teardown/params/CUSTOM_SETTINGS/PR/admin/dev/admin-4-angular-on-nginx-dc.params
@@ -6,3 +6,4 @@ TAG_NAME=latest
 BANNER_COLOUR=orange
 REMOTE_API_PATH=https://eagle-pr-placeholder-dev.pathfinder.gov.bc.ca/api
 REMOTE_PUBLIC_PATH=https://eagle-pr-placeholder-dev.pathfinder.gov.bc.ca
+KEYCLOAK_CLIENT_ID=eagle-admin-pr-console


### PR DESCRIPTION
A new keycloak client is available to use for PR builds, intended to keep redirect URI's for PRs separate from the main eagle client.