### PR TITLE
Revert "prepend name with dev to ensure service names are valid"

### DIFF
--- a/openshift/setup-teardown/params/CUSTOM_SETTINGS/PR/admin/dev/admin-4-angular-on-nginx-dc.params
+++ b/openshift/setup-teardown/params/CUSTOM_SETTINGS/PR/admin/dev/admin-4-angular-on-nginx-dc.params
@@ -1,4 +1,4 @@
-NAME=dev-pr-placeholder-eagle-admin
+NAME=pr-placeholder-eagle-admin
 GROUP_NAME=pr-placeholder-epic
 IMAGE_NAMESPACE=esm
 APPLICATION_DOMAIN=eagle-pr-placeholder-dev.pathfinder.gov.bc.ca

--- a/openshift/setup-teardown/params/CUSTOM_SETTINGS/PR/api/dev/api-3-nodejs-dc.params
+++ b/openshift/setup-teardown/params/CUSTOM_SETTINGS/PR/api/dev/api-3-nodejs-dc.params
@@ -1,4 +1,4 @@
-NAME=dev-pr-placeholder-eagle-api
+NAME=pr-placeholder-eagle-api
 GROUP_NAME=pr-placeholder-epic
 APPLICATION_DOMAIN=eagle-pr-placeholder-dev.pathfinder.gov.bc.ca
 MINIO_HOST=pr-placeholder-eagle-api-minio-esm-dev.pathfinder.gov.bc.ca

--- a/openshift/setup-teardown/params/CUSTOM_SETTINGS/PR/public/dev/public-4-angular-on-nginx-dc.params
+++ b/openshift/setup-teardown/params/CUSTOM_SETTINGS/PR/public/dev/public-4-angular-on-nginx-dc.params
@@ -1,4 +1,4 @@
-NAME=dev-pr-placeholder-eagle-public
+NAME=pr-placeholder-eagle-public
 GROUP_NAME=pr-placeholder-epic
 IMAGE_NAMESPACE=esm
 APPLICATION_DOMAIN=eagle-pr-placeholder-dev.pathfinder.gov.bc.ca


### PR DESCRIPTION
This reverts commit 3b80496bff3efd7af8824722d578884f67a0be3f.

The prepend is unncessary as we will instead enforce a branch naming rule:

* branch names must start with a letter character 

This ensures all Openshift objects for PR deployments are created successfully