### PR TITLE
EE-1159 Update for data generator image

### DIFF
--- a/openshift/setup-teardown/params/CUSTOM_SETTINGS/PR/admin/tools/admin-1-angular-builder-bc.params
+++ b/openshift/setup-teardown/params/CUSTOM_SETTINGS/PR/admin/tools/admin-1-angular-builder-bc.params
@@ -1,3 +1,4 @@
 NAME=pr-placeholder-eagle-admin-angular-builder
+GROUP_NAME=pr-placeholder-epic
 GIT_REPO_URL=https://github.com/fork-placeholder/eagle-admin
 GIT_REPO_BRANCH=branch-placeholder

--- a/openshift/setup-teardown/params/CUSTOM_SETTINGS/PR/admin/tools/admin-2-nginx-runtime-bc.params
+++ b/openshift/setup-teardown/params/CUSTOM_SETTINGS/PR/admin/tools/admin-2-nginx-runtime-bc.params
@@ -1,3 +1,4 @@
 NAME=pr-placeholder-eagle-admin-nginx-runtime
+GROUP_NAME=pr-placeholder-epic
 GIT_REPO_URL=https://github.com/fork-placeholder/eagle-admin
 GIT_REPO_BRANCH=branch-placeholder

--- a/openshift/setup-teardown/params/CUSTOM_SETTINGS/PR/admin/tools/admin-3-angular-on-nginx-bc.params
+++ b/openshift/setup-teardown/params/CUSTOM_SETTINGS/PR/admin/tools/admin-3-angular-on-nginx-bc.params
@@ -1,3 +1,4 @@
 NAME=pr-placeholder-eagle-admin
+GROUP_NAME=pr-placeholder-epic
 ANGULAR_BUILDER_IMAGE=pr-placeholder-eagle-admin-angular-builder
 NGINX_RUNTIME_IMAGE=pr-placeholder-eagle-admin-nginx-runtime

--- a/openshift/setup-teardown/params/CUSTOM_SETTINGS/PR/api/tools/api-1-nodejs-bc.params
+++ b/openshift/setup-teardown/params/CUSTOM_SETTINGS/PR/api/tools/api-1-nodejs-bc.params
@@ -1,4 +1,5 @@
 NAME=pr-placeholder-eagle-api
+GROUP_NAME=pr-placeholder-epic
 SOURCE_REPOSITORY_URL=https://github.com/fork-placeholder/eagle-api
 SOURCE_REPOSITORY_REF=branch-placeholder
-NODE_ENV=development
+#NODE_ENV=development

--- a/openshift/setup-teardown/params/CUSTOM_SETTINGS/PR/api/tools/api-1-nodejs-bc.params
+++ b/openshift/setup-teardown/params/CUSTOM_SETTINGS/PR/api/tools/api-1-nodejs-bc.params
@@ -2,4 +2,3 @@ NAME=pr-placeholder-eagle-api
 GROUP_NAME=pr-placeholder-epic
 SOURCE_REPOSITORY_URL=https://github.com/fork-placeholder/eagle-api
 SOURCE_REPOSITORY_REF=branch-placeholder
-#NODE_ENV=development

--- a/openshift/setup-teardown/params/CUSTOM_SETTINGS/PR/public/tools/public-1-angular-builder-bc.params
+++ b/openshift/setup-teardown/params/CUSTOM_SETTINGS/PR/public/tools/public-1-angular-builder-bc.params
@@ -1,3 +1,4 @@
 NAME=pr-placeholder-eagle-public-angular-builder
+GROUP_NAME=pr-placeholder-epic
 GIT_REPO_URL=https://github.com/fork-placeholder/eagle-public
 GIT_REPO_BRANCH=branch-placeholder

--- a/openshift/setup-teardown/params/CUSTOM_SETTINGS/PR/public/tools/public-2-nginx-runtime-bc.params
+++ b/openshift/setup-teardown/params/CUSTOM_SETTINGS/PR/public/tools/public-2-nginx-runtime-bc.params
@@ -1,3 +1,4 @@
 NAME=pr-placeholder-eagle-public-nginx-runtime
+GROUP_NAME=pr-placeholder-epic
 GIT_REPO_URL=https://github.com/fork-placeholder/eagle-public
 GIT_REPO_BRANCH=branch-placeholder

--- a/openshift/setup-teardown/params/CUSTOM_SETTINGS/PR/public/tools/public-3-angular-on-nginx-bc.params
+++ b/openshift/setup-teardown/params/CUSTOM_SETTINGS/PR/public/tools/public-3-angular-on-nginx-bc.params
@@ -1,3 +1,4 @@
 NAME=pr-placeholder-eagle-public
+GROUP_NAME=pr-placeholder-epic
 ANGULAR_BUILDER_IMAGE=pr-placeholder-eagle-public-angular-builder
 NGINX_RUNTIME_IMAGE=pr-placeholder-eagle-public-nginx-runtime

--- a/openshift/setup-teardown/teardown-all.sh
+++ b/openshift/setup-teardown/teardown-all.sh
@@ -41,11 +41,13 @@ cleanApi() {
 
     removeFromProject ${API_MINIO_BUILD_NAME} ${TOOLS_PROJECT}
     removeFromProject ${API_NODEJS_BUILD_NAME} ${TOOLS_PROJECT}
+    removeFromProject ${API_NODEJS_BUILD_NAME}-generator ${TOOLS_PROJECT}
     removeFromProject ${API_MINIO_BUILD_NAME} ${TOOLS_PROJECT}
 
     echo -e \\n"clean-api: Removing deployments."\\n;
 
     removeFromProject ${API_NODEJS_DEPLOYMENT_NAME} ${TARGET_PROJECT}
+    removeFromProject ${API_NODEJS_DEPLOYMENT_NAME}-generator ${TARGET_PROJECT}
     removeFromProject ${API_MONGODB_DEPLOYMENT_NAME} ${TARGET_PROJECT}
     removeFromProject ${API_MONGODB_DEPLOYMENT_NAME}-data ${TARGET_PROJECT}
     removeFromProject ${API_MINIO_DEPLOYMENT_NAME} ${TARGET_PROJECT}


### PR DESCRIPTION
https://bcmines.atlassian.net/browse/EE-1159

- Added GROUP_NAME to build config .param files.  This allows build config templates to use GROUP_NAME for the app label.  This will allow the use of app=GROUP_NAME selector to more efficiently select a group of PR builds
- Commented out NODE_ENV=development for API dev builds.  The data generator image will use dev build instead
- Added data generator image configs to the tear down script