### PR TITLE
NOBUG: append -build to angular-on-nginx names to ensure cleanup

### DIFF
--- a/openshift/setup-teardown/params/CUSTOM_SETTINGS/PR/admin/admin.config
+++ b/openshift/setup-teardown/params/CUSTOM_SETTINGS/PR/admin/admin.config
@@ -1,6 +1,6 @@
 ADMIN_ANGULAR_BUILDER_BUILD_NAME=pr-placeholder-eagle-admin-angular-builder
 ADMIN_NGINX_RUNTIME_BUILD_NAME=pr-placeholder-eagle-admin-nginx-runtime
-ADMIN_ANGULAR_ON_NGINX_BUILD_NAME=pr-placeholder-eagle-admin
+ADMIN_ANGULAR_ON_NGINX_BUILD_NAME=pr-placeholder-eagle-admin-build
 ADMIN_ANGULAR_ON_NGINX_DEPLOYMENT_NAME=pr-placeholder-eagle-admin
 ADMIN_BC_ANGULAR_BUILDER_TEMPLATE_FOLDER_URL=https://raw.githubusercontent.com/fork-placeholder/eagle-admin/branch-placeholder/openshift/templates/angular-builder/
 ADMIN_BC_NGINX_RUNTIME_TEMPLATE_FOLDER_URL=https://raw.githubusercontent.com/fork-placeholder/eagle-admin/branch-placeholder/openshift/templates/nginx-runtime/

--- a/openshift/setup-teardown/params/CUSTOM_SETTINGS/PR/public/public.config
+++ b/openshift/setup-teardown/params/CUSTOM_SETTINGS/PR/public/public.config
@@ -1,6 +1,6 @@
 PUBLIC_ANGULAR_BUILDER_BUILD_NAME=pr-placeholder-eagle-public-angular-builder
 PUBLIC_NGINX_RUNTIME_BUILD_NAME=pr-placeholder-eagle-public-nginx-runtime
-PUBLIC_ANGULAR_ON_NGINX_BUILD_NAME=pr-placeholder-eagle-public
+PUBLIC_ANGULAR_ON_NGINX_BUILD_NAME=pr-placeholder-eagle-public-build
 PUBLIC_ANGULAR_ON_NGINX_DEPLOYMENT_NAME=pr-placeholder-eagle-public
 PUBLIC_BC_ANGULAR_BUILDER_TEMPLATE_FOLDER_URL=https://raw.githubusercontent.com/fork-placeholder/eagle-public/branch-placeholder/openshift/templates/angular-builder/
 PUBLIC_BC_NGINX_RUNTIME_TEMPLATE_FOLDER_URL=https://raw.githubusercontent.com/fork-placeholder/eagle-public/branch-placeholder/openshift/templates/nginx-runtime/


### PR DESCRIPTION
NOTE:
ADMIN_ANGULAR_ON_NGINX_BUILD_NAME variable and its public version are only used by the teardown script. The setup script takes it's name from the params file and has -build appended in the bc templates.